### PR TITLE
chore: rename all web_crawler references to web-crawler

### DIFF
--- a/.github/workflows/docker-publish-master.yml
+++ b/.github/workflows/docker-publish-master.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/bluedotiya/web_crawler
+  IMAGE_PREFIX: ghcr.io/bluedotiya/web-crawler
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Release & Publish](https://github.com/bluedotiya/web_crawler/actions/workflows/docker-publish-master.yml/badge.svg)](https://github.com/bluedotiya/web_crawler/actions/workflows/docker-publish-master.yml)[![PR Title Check](https://github.com/bluedotiya/web_crawler/actions/workflows/pr-title.yml/badge.svg)](https://github.com/bluedotiya/web_crawler/actions/workflows/pr-title.yml)
+[![Release & Publish](https://github.com/bluedotiya/web-crawler/actions/workflows/docker-publish-master.yml/badge.svg)](https://github.com/bluedotiya/web-crawler/actions/workflows/docker-publish-master.yml)[![PR Title Check](https://github.com/bluedotiya/web-crawler/actions/workflows/pr-title.yml/badge.svg)](https://github.com/bluedotiya/web-crawler/actions/workflows/pr-title.yml)
 
 # Web Crawler
 
@@ -33,7 +33,7 @@ Recursive web crawler built in Rust. Feed it one URL and the crawler will map al
 ### Install
 
 ```bash
-helm install web-crawler oci://ghcr.io/bluedotiya/web_crawler/charts/web-crawler \
+helm install web-crawler oci://ghcr.io/bluedotiya/web-crawler/charts/web-crawler \
   --version 1.0.0 -n web-crawler --create-namespace
 ```
 
@@ -127,10 +127,10 @@ PR titles **must** follow [conventional commit](https://www.conventionalcommits.
 ### Docker images
 
 ```
-ghcr.io/bluedotiya/web_crawler/feeder:latest
-ghcr.io/bluedotiya/web_crawler/feeder:1.0.0
-ghcr.io/bluedotiya/web_crawler/manager:latest
-ghcr.io/bluedotiya/web_crawler/manager:1.0.0
+ghcr.io/bluedotiya/web-crawler/feeder:latest
+ghcr.io/bluedotiya/web-crawler/feeder:1.0.0
+ghcr.io/bluedotiya/web-crawler/manager:latest
+ghcr.io/bluedotiya/web-crawler/manager:1.0.0
 ```
 
 ### Helm chart (OCI)
@@ -139,14 +139,14 @@ The Helm chart is published as an OCI artifact to GHCR. No `helm repo add` is ne
 
 ```bash
 # Install from GHCR OCI registry
-helm install web-crawler oci://ghcr.io/bluedotiya/web_crawler/charts/web-crawler \
+helm install web-crawler oci://ghcr.io/bluedotiya/web-crawler/charts/web-crawler \
   --version 1.0.1 -n web-crawler --create-namespace
 
 # Pull chart locally
-helm pull oci://ghcr.io/bluedotiya/web_crawler/charts/web-crawler --version 1.0.1
+helm pull oci://ghcr.io/bluedotiya/web-crawler/charts/web-crawler --version 1.0.1
 
 # Inspect chart metadata
-helm show all oci://ghcr.io/bluedotiya/web_crawler/charts/web-crawler --version 1.0.1
+helm show all oci://ghcr.io/bluedotiya/web-crawler/charts/web-crawler --version 1.0.1
 ```
 
 ## Configuration
@@ -155,7 +155,7 @@ Customize via `--set` flags or a values override file:
 
 ```bash
 # From OCI registry with overrides
-helm install web-crawler oci://ghcr.io/bluedotiya/web_crawler/charts/web-crawler \
+helm install web-crawler oci://ghcr.io/bluedotiya/web-crawler/charts/web-crawler \
   --version 1.0.1 -n web-crawler --create-namespace \
   --set feeder.replicaCount=16 \
   --set neo4j.neo4j.password=SecurePassword123

--- a/dev.sh
+++ b/dev.sh
@@ -10,8 +10,8 @@ NAMESPACE="web-crawler"
 RELEASE="web-crawler"
 CHART="$REPO_ROOT/web-crawler"
 
-FEEDER_IMAGE="ghcr.io/bluedotiya/web_crawler/feeder"
-MANAGER_IMAGE="ghcr.io/bluedotiya/web_crawler/manager"
+FEEDER_IMAGE="ghcr.io/bluedotiya/web-crawler/feeder"
+MANAGER_IMAGE="ghcr.io/bluedotiya/web-crawler/manager"
 TAG="latest"
 
 echo "==> Building Docker image $FEEDER_IMAGE:$TAG..."

--- a/web-crawler/charts/feeder/values.yaml
+++ b/web-crawler/charts/feeder/values.yaml
@@ -3,7 +3,7 @@
 replicaCount: 8
 
 image:
-  repository: ghcr.io/bluedotiya/web_crawler/feeder
+  repository: ghcr.io/bluedotiya/web-crawler/feeder
   tag: latest
   pullPolicy: IfNotPresent
 

--- a/web-crawler/charts/manager/values.yaml
+++ b/web-crawler/charts/manager/values.yaml
@@ -3,7 +3,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/bluedotiya/web_crawler/manager
+  repository: ghcr.io/bluedotiya/web-crawler/manager
   tag: latest
   pullPolicy: IfNotPresent
 

--- a/web-crawler/templates/NOTES.txt
+++ b/web-crawler/templates/NOTES.txt
@@ -87,6 +87,6 @@ Namespace: {{ .Release.Namespace }}
   - Configure proper StorageClass in values.yaml for persistent storage
   - Update Neo4j password in values.yaml for production use
 
-📖 Documentation: https://github.com/bluedotiya/web_crawler
+📖 Documentation: https://github.com/bluedotiya/web-crawler
 
 Happy Crawling! 🕷️

--- a/web-crawler/values.yaml
+++ b/web-crawler/values.yaml
@@ -45,7 +45,7 @@ feeder:
   replicaCount: 8
 
   image:
-    repository: ghcr.io/bluedotiya/web_crawler/feeder
+    repository: ghcr.io/bluedotiya/web-crawler/feeder
     tag: latest
     pullPolicy: IfNotPresent
 
@@ -79,7 +79,7 @@ manager:
   replicaCount: 1
 
   image:
-    repository: ghcr.io/bluedotiya/web_crawler/manager
+    repository: ghcr.io/bluedotiya/web-crawler/manager
     tag: latest
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Update all GHCR image paths from `bluedotiya/web_crawler` to `bluedotiya/web-crawler`
- Update GitHub URLs, CI workflow, Helm values, dev.sh, NOTES.txt, and README
- Old GHCR packages have been deleted manually

## Test plan
- [ ] Merge and verify CI creates new packages under `web-crawler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)