### PR TITLE
chore: trigger Docker image build under new repo name

### DIFF
--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shared"
 version = "1.0.0"
 edition = "2021"
+description = "Shared library for web-crawler services"
 
 [dependencies]
 reqwest = { workspace = true }


### PR DESCRIPTION
## Summary
- Add description field to shared crate to trigger feeder + manager Docker builds
- First build under the renamed `web-crawler` GHCR path

## Test plan
- [ ] Verify `build-feeder` and `build-manager` jobs run and push to `ghcr.io/bluedotiya/web-crawler/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)