### PR TITLE
fix(ci): correct worktree.io action name to comment-action

### DIFF
--- a/.github/workflows/worktree.yml
+++ b/.github/workflows/worktree.yml
@@ -9,4 +9,4 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: worktree-io/action@v1
+      - uses: worktree-io/comment-action@v1


### PR DESCRIPTION
## Summary
- Fix the worktree.io GitHub Action reference from `worktree-io/action@v1` to `worktree-io/comment-action@v1`
- The documented action name on worktree.io is incorrect — the actual repo is [`worktree-io/comment-action`](https://github.com/worktree-io/comment-action)
- Reported upstream: https://github.com/worktree-io/landing/issues/14

## Test plan
- [x] Verified the fix works — workflow ran successfully and posted a comment on [#36](https://github.com/nabi-allenby/web-crawler/issues/36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)