### PR TITLE
feat: use HTML parser (scraper crate) instead of regex for URL extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +373,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +432,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +468,27 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "encoding_rs"
@@ -538,6 +599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +698,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +714,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -740,6 +829,18 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "match_token",
 ]
 
 [[package]]
@@ -1104,6 +1205,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "manager"
 version = "1.0.0"
 dependencies = [
@@ -1123,6 +1230,31 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1244,6 +1376,12 @@ dependencies = [
  "quote",
  "syn 2.0.115",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1383,6 +1521,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -1404,6 +1543,19 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1456,6 +1608,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -1756,6 +1914,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3d051b884f40e309de6c149734eab57aa8cc1347992710dc80bcc1c2194c15"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,6 +1962,25 @@ checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -1858,6 +2050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,11 +2086,12 @@ dependencies = [
  "hickory-resolver",
  "neo4rs",
  "psl",
- "regex",
  "reqwest",
+ "scraper",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1959,6 +2161,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,6 +2250,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -2319,6 +2557,12 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ neo4rs = "0.8"
 # NOTE: default-features = false is ignored at workspace level; each member crate must set it explicitly
 reqwest = { version = "0.12", default-features = false, features = ["native-tls", "charset", "http2"] }
 hickory-resolver = { version = "0.25", features = ["tokio", "system-config"] }
-regex = "1"
 rand = "0.8"
 anyhow = "1"
 thiserror = "2"

--- a/feeder/src/job.rs
+++ b/feeder/src/job.rs
@@ -289,7 +289,8 @@ pub async fn feeding(
     };
 
     // Step 2: Extract URLs from HTML and normalize once
-    let extracted_urls = crawler::extract_urls(&page_data.html);
+    let full_url = format!("{}{}", job.http_type, job.name);
+    let extracted_urls = crawler::extract_urls(&page_data.html, &full_url);
     let mut normalized_map: HashMap<String, (String, String)> = HashMap::new();
     for url in &extracted_urls {
         let (norm_name, http_type) = url_normalize::normalize_url(url);

--- a/manager/src/routes/crawl.rs
+++ b/manager/src/routes/crawl.rs
@@ -72,7 +72,7 @@ pub async fn create_crawl(
     };
 
     // 3. Extract URLs from HTML
-    let extracted_urls = crawler::extract_urls(&page_data.html);
+    let extracted_urls = crawler::extract_urls(&page_data.html, &req.url);
 
     // 4. Generate unique crawl ID
     let crawl_id = Uuid::new_v4().to_string();

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -9,11 +9,12 @@ description = "Shared library for web-crawler services"
 reqwest = { workspace = true, default-features = false }
 hickory-resolver = { workspace = true }
 neo4rs = { workspace = true }
-regex = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 futures = { workspace = true }
 psl = "2"
+scraper = "0.22"
+url = "2"
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/shared/src/crawler.rs
+++ b/shared/src/crawler.rs
@@ -1,12 +1,13 @@
-use regex::Regex;
 use reqwest::Client;
+use scraper::{Html, Selector};
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
+use url::Url;
 
 use crate::error::CrawlerError;
 
-static URL_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"https?://[\w\-.]+(?::\d+)?").unwrap());
+static ANCHOR_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("a[href]").unwrap());
 
 pub struct PageData {
     pub html: String,
@@ -50,12 +51,23 @@ pub async fn get_page_data(client: &Client, url: &str) -> Result<PageData, Crawl
     })
 }
 
-/// Extracts URLs from HTML content.
-/// Pattern: `https?://[\w\-.]+(?::\d+)?` — captures protocol + domain + optional port.
-pub fn extract_urls(html: &str) -> Vec<String> {
-    URL_REGEX
-        .find_iter(html)
-        .map(|m| m.as_str().to_string())
+/// Extracts URLs from `<a href="...">` tags in HTML content.
+/// Resolves relative URLs against the given base URL.
+/// Only returns URLs with http or https schemes.
+pub fn extract_urls(html: &str, base_url: &str) -> Vec<String> {
+    let base = match Url::parse(base_url) {
+        Ok(u) => u,
+        Err(_) => return Vec::new(),
+    };
+
+    let document = Html::parse_document(html);
+
+    document
+        .select(&ANCHOR_SELECTOR)
+        .filter_map(|el| el.value().attr("href"))
+        .filter_map(|href| base.join(href).ok())
+        .filter(|url| url.scheme() == "http" || url.scheme() == "https")
+        .map(|url| url.to_string())
         .collect()
 }
 
@@ -63,52 +75,111 @@ pub fn extract_urls(html: &str) -> Vec<String> {
 mod tests {
     use super::*;
 
+    const BASE: &str = "https://example.com/page";
+
     #[test]
     fn test_extract_urls_basic() {
-        let html = r#"<a href="https://google.com">link</a> and http://example.org too"#;
-        let urls = extract_urls(html);
-        assert_eq!(urls, vec!["https://google.com", "http://example.org"]);
+        let html = r#"<a href="https://google.com">link</a> <a href="http://example.org">other</a>"#;
+        let urls = extract_urls(html, BASE);
+        assert_eq!(
+            urls,
+            vec!["https://google.com/", "http://example.org/"]
+        );
     }
 
     #[test]
-    fn test_extract_urls_strips_paths() {
-        let html = "Visit https://example.com/path/to/page for more";
-        let urls = extract_urls(html);
-        assert_eq!(urls, vec!["https://example.com"]);
+    fn test_extract_urls_preserves_paths() {
+        let html = r#"<a href="https://example.com/path/to/page">link</a>"#;
+        let urls = extract_urls(html, BASE);
+        assert_eq!(urls, vec!["https://example.com/path/to/page"]);
     }
 
     #[test]
     fn test_extract_urls_empty() {
-        assert!(extract_urls("no urls here").is_empty());
+        assert!(extract_urls("no urls here", BASE).is_empty());
     }
 
     #[test]
-    fn test_extract_urls_multiple_same_page() {
-        let html = "https://a.com https://b.com http://c.org https://a.com";
-        let urls = extract_urls(html);
+    fn test_extract_urls_no_anchor_tags() {
+        let html = "<p>https://example.com</p>";
+        assert!(extract_urls(html, BASE).is_empty());
+    }
+
+    #[test]
+    fn test_extract_urls_multiple() {
+        let html = r#"<a href="https://a.com">A</a> <a href="https://b.com">B</a> <a href="http://c.org">C</a>"#;
+        let urls = extract_urls(html, BASE);
         assert_eq!(
             urls,
-            vec!["https://a.com", "https://b.com", "http://c.org", "https://a.com"]
+            vec!["https://a.com/", "https://b.com/", "http://c.org/"]
         );
     }
 
     #[test]
     fn test_extract_urls_with_hyphens_and_dots() {
-        let html = "https://my-site.co.uk and http://sub.example-domain.com";
-        let urls = extract_urls(html);
+        let html = r#"<a href="https://my-site.co.uk">1</a> <a href="http://sub.example-domain.com">2</a>"#;
+        let urls = extract_urls(html, BASE);
         assert_eq!(
             urls,
-            vec!["https://my-site.co.uk", "http://sub.example-domain.com"]
+            vec!["https://my-site.co.uk/", "http://sub.example-domain.com/"]
         );
     }
 
     #[test]
     fn test_extract_urls_with_ports() {
-        let html = "Visit https://example.com:8080/path and http://localhost:3000 for more";
-        let urls = extract_urls(html);
+        let html = r#"<a href="https://example.com:8080/path">1</a> <a href="http://localhost:3000">2</a>"#;
+        let urls = extract_urls(html, BASE);
         assert_eq!(
             urls,
-            vec!["https://example.com:8080", "http://localhost:3000"]
+            vec!["https://example.com:8080/path", "http://localhost:3000/"]
         );
+    }
+
+    #[test]
+    fn test_extract_urls_relative_path() {
+        let html = r#"<a href="/about">About</a>"#;
+        let urls = extract_urls(html, "https://example.com/index.html");
+        assert_eq!(urls, vec!["https://example.com/about"]);
+    }
+
+    #[test]
+    fn test_extract_urls_relative_sibling() {
+        let html = r#"<a href="contact.html">Contact</a>"#;
+        let urls = extract_urls(html, "https://example.com/pages/index.html");
+        assert_eq!(urls, vec!["https://example.com/pages/contact.html"]);
+    }
+
+    #[test]
+    fn test_extract_urls_with_query_and_fragment() {
+        let html = r#"<a href="https://example.com/search?q=rust#results">Search</a>"#;
+        let urls = extract_urls(html, BASE);
+        assert_eq!(urls, vec!["https://example.com/search?q=rust#results"]);
+    }
+
+    #[test]
+    fn test_extract_urls_skips_non_http() {
+        let html = r#"<a href="mailto:user@example.com">Email</a> <a href="ftp://files.example.com">FTP</a> <a href="https://example.com">Web</a>"#;
+        let urls = extract_urls(html, BASE);
+        assert_eq!(urls, vec!["https://example.com/"]);
+    }
+
+    #[test]
+    fn test_extract_urls_skips_javascript() {
+        let html = r#"<a href="javascript:void(0)">Click</a> <a href="https://real.com">Real</a>"#;
+        let urls = extract_urls(html, BASE);
+        assert_eq!(urls, vec!["https://real.com/"]);
+    }
+
+    #[test]
+    fn test_extract_urls_invalid_base() {
+        let html = r#"<a href="/about">About</a>"#;
+        assert!(extract_urls(html, "not-a-url").is_empty());
+    }
+
+    #[test]
+    fn test_extract_urls_protocol_relative() {
+        let html = r#"<a href="//cdn.example.com/lib.js">CDN</a>"#;
+        let urls = extract_urls(html, "https://example.com/page");
+        assert_eq!(urls, vec!["https://cdn.example.com/lib.js"]);
     }
 }


### PR DESCRIPTION
## Summary
- Replace custom regex (`r"https?://[\w\-.]+(?::\d+)?"`) with the `scraper` crate to parse HTML and extract URLs from `<a href="...">` tags
- Resolve relative URLs against the page's base URL using the `url` crate
- Remove `regex` dependency from workspace and `shared` crate, add `scraper` and `url`
- Update callers in `feeder` and `manager` to pass base URL to the new `extract_urls(html, base_url)` signature
- Expand test suite from 6 to 14 tests covering relative paths, query strings, fragments, protocol-relative URLs, non-http scheme filtering, and invalid base URL handling

## Test plan
- [x] All 40 shared crate tests pass (`cargo test -p shared`)
- [x] Full project compiles (`cargo check`)
- [ ] Manual integration test: crawl a site and verify URLs with paths/query strings are now discovered

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)