### PR TITLE
fix: make cancel operation durable — prevent feeders from overwriting CANCELLED status

### DIFF
--- a/feeder/src/job.rs
+++ b/feeder/src/job.rs
@@ -86,6 +86,7 @@ async fn update_job_status(
 ) -> Result<(), anyhow::Error> {
     let q = query(
         "MATCH (n:URL {name: $name, http_type: $http_type, current_depth: $current_depth, crawl_id: $crawl_id}) \
+         WHERE n.job_status <> 'CANCELLED' \
          SET n.job_status = $status, n.attempts = $attempts",
     )
     .param("name", job.name.as_str())
@@ -371,10 +372,18 @@ pub async fn feeding(
         return Ok(false);
     }
 
-    // Step 6: Batch-create nodes and relationships
+    // Step 6: Re-check cancellation before creating children.
+    // This closes the race window where a cancel fires after the initial
+    // is_cancelled check but before we persist new PENDING children.
+    if is_cancelled(graph, job).await? {
+        tracing::info!("Job {} cancelled during processing, skipping child creation", job.name);
+        return Ok(false);
+    }
+
+    // Step 7: Batch-create nodes and relationships
     batch_create_children(graph, job, &children).await?;
 
-    // Step 7: Mark COMPLETED
+    // Step 8: Mark COMPLETED
     update_job_status(graph, job, "COMPLETED", job.attempts).await?;
     Ok(true)
 }


### PR DESCRIPTION
## Summary
- Add `WHERE n.job_status <> 'CANCELLED'` guard to `update_job_status` so feeders can no longer overwrite CANCELLED back to COMPLETED
- Re-check `is_cancelled()` right before `batch_create_children()` to prevent new PENDING children from being created after cancellation
- Together these close the race window where a cancel fires mid-processing

## Test plan
- [ ] Start a deep crawl (e.g., `https://wikipedia.org` at depth 5)
- [ ] Wait until feeders are actively processing
- [ ] Cancel via `DELETE /api/v1/crawls/:id`
- [ ] Verify crawl stops within seconds and no new children are created
- [ ] Verify `cancelled` count reflects the cancelled URLs

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)